### PR TITLE
feat: Add user agent header to graph requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ await subgraph.query<{ elements: Element[] }>(getElementsQuery(), { count: 5 })
 
 It supports the following ENV variables:
 
-- `SUBGRAPH_COMPONENT_RETRIES`: How many retries per subraph query. Defaults to `3`.
+- `SUBGRAPH_COMPONENT_RETRIES`: How many retries per subgraph query. Defaults to `3`.
 - `SUBGRAPH_COMPONENT_QUERY_TIMEOUT`: How long to wait until a connection is timed-out. Defaults to `10000`ms or 10 seconds.
 - `SUBGRAPH_COMPONENT_TIMEOUT_INCREMENT`: How much time to add after each retry. The value will be multiplied for the attempt number. For example: if the increment is 10000, it'll wait 10s the first retry, 20s next, 30s, etc. Defaults to `10000`ms or 10 seconds.
-- `SUBGRAPH_COMPONENT_BACKOFF`: How long to wait until a new query is tried after an unsuccessfull one (retrying). Defaults to `500`ms.
+- `SUBGRAPH_COMPONENT_BACKOFF`: How long to wait until a new query is tried after an unsuccessful one (retrying). Defaults to `500`ms.
+- `SUBGRAPH_COMPONENT_AGENT_NAME`: The name of the agent that will be performing the graph requests. This agent name will be used to identify the graph requests using the user agent header. The crafted header will be: `Subgraph component / Agent Name`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,9 @@ export async function createSubgraphComponent(
   const TIMEOUT = (await config.getNumber("SUBGRAPH_COMPONENT_QUERY_TIMEOUT")) ?? 10000
   const TIMEOUT_INCREMENT = (await config.getNumber("SUBGRAPH_COMPONENT_TIMEOUT_INCREMENT")) ?? 10000
   const BACKOFF = (await config.getNumber("SUBGRAPH_COMPONENT_BACKOFF")) ?? 500
+  const USER_AGENT = `Subgraph component / ${
+    (await config.getString("SUBGRAPH_COMPONENT_AGENT_NAME")) ?? "Unknown sender"
+  }`
 
   async function executeQuery<T>(
     query: string,
@@ -84,7 +87,7 @@ export async function createSubgraphComponent(
   ): Promise<SubgraphResponse<T>> {
     const response = await fetch.fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", "User-agent": USER_AGENT },
       body: JSON.stringify({ query, variables }),
       signal: abortController.signal,
     })


### PR DESCRIPTION
This PR adds a configurable user agent to the graph fetch request. This will help track requests done to the graphs.